### PR TITLE
Add: progress bar to draft registration form

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -325,15 +325,23 @@ var Draft = function(params, metaSchema) {
         if (self.schemaData) {
             var schema = self.schema();
             $.each(schema.pages, function(i, page) {
+                var completedQuestions = 0;
                 $.each(page.questions, function(qid, question) {
                     var q = self.schemaData[qid];
-                    if(q && !$osf.isBlank(q.value)) {
-                        complete++;
+                    // questions with an uploader have the question.value attr instead
+                    if (q && q.question) {
+                        if(!$osf.isBlank(q.question.value))
+                            completedQuestions++;
+                    } else {
+                        if(q && !$osf.isBlank(q.value))
+                            completedQuestions++;
                     }
-                    total++;
+                    if ( completedQuestions === Object.keys(page.questions).length )
+                        complete++;
                 });
+                total++;
             });
-	    return Math.ceil(100 * (complete / total));
+            return Math.ceil(100 * (complete / total));
         }
         return 0;
     });
@@ -726,6 +734,10 @@ RegistrationEditor.prototype.create = function(schemaData) {
         schema_version: metaSchema.version,
         schema_data: schemaData
     }).then(self.updateData.bind(self));
+};
+RegistrationEditor.prototype.getCompletion = function() {
+    var self = this;
+    return self.draft().completion();
 };
 RegistrationEditor.prototype.putSaveData = function(payload) {
     var self = this;

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -73,7 +73,13 @@
                               }" style="float:right; padding-right:5px;">Next
                   <i style="display:inline-block; padding-right: 5px; padding-left: 5px;" class="fa fa-arrow-right"></i>
                 </a>
-                <br />
+                <div class="progress progress-bar-md">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuemin="0" aria-valuemax="100"
+                        data-bind="attr.aria-completion: getCompletion,
+                                  style: {width: getCompletion() + '%'}">
+                        <span class="sr-only"></span>
+                    </div>
+                </div>
                 <br />
                 <!-- EDITOR -->
                 <div data-bind="if: currentQuestion">


### PR DESCRIPTION
Per [OSF-4332]
- Progress bar shows across the top of the form
- Progress bar shows the current value of the progress (as a percentage)
- Progress is calculated by **section**
- Screenshot when one of five sections is completed:
  ![screen shot 2015-09-17 at 11 31 17 am](https://cloud.githubusercontent.com/assets/8905795/9938113/d4c2b362-5d31-11e5-8f56-a17e51c378e7.png)
