### PR TITLE
Fix callback chain for preregisterPrompts/Errors

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -281,7 +281,7 @@ Draft.prototype.beforeRegister = function(data) {
 
     return $.getJSON(self.urls.before_register).then(function(response) {
         if (response.errors && response.errors.length) {
-            self.preRegisterErrors(response, self.preRegisterWarnings);
+            self.preRegisterErrors(response, self.preRegisterPrompts.bind(self, response, self.register.bind(self)));
         } else if (response.prompts && response.prompts.length) {
             self.preRegisterPrompts(response, self.register.bind(self, data));
         } else {


### PR DESCRIPTION
# Purpose

A bug in the preregisterError/Prompt logic was causing an exception to get raised for addons that get preregisterErrors. Trying to register private figshare can consistently replicate this.
# Changes

 Fix the callback chain by binding the right callbacks and callback parameters. 
