### PR TITLE
Fix display of update time for drafts that have been saved

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -393,13 +393,23 @@ var RegistrationEditor = function(urls, editorId) {
     self.lastSaved = ko.computed(function() {
         var request = self.lastSaveRequest();
         if (request !== undefined) {
+            // If an autosave event has already occurred during this pageview
             if (request.completedDate !== undefined) {
-                return request.completedDate.toGMTString();
+                return request.completedDate.toUTCString();
             } else {
                 return 'pending';
             }
         } else {
-            return 'never';
+            // If viewing a new or previously worked on draft registration. Note that "updated" is never undefined,
+            //  even for a newly created registration
+            var draft = self.draft();
+            var startDate = draft ? self.draft().initiated : undefined;
+            var updateDate = draft ? self.draft().updated : undefined;
+            if (updateDate && startDate.getTime() !== updateDate.getTime()) {
+                return updateDate.toUTCString();
+            } else {
+                return 'never';
+            }
         }
     });
 


### PR DESCRIPTION
(but not in this viewing)

Should display updated time, instead of never. Only show "never" if the update time == creation time. Given that a draft registration is created on click regardless of time, the exact value of "never' is questionable. If we don't show "never", the code is a bit simpler.

[#OSF-5057]
